### PR TITLE
#156005300 Add fastlane integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/app/src/main/java/com/example/wagubibrian/github_connect/model/GithubUsers.java
+++ b/app/src/main/java/com/example/wagubibrian/github_connect/model/GithubUsers.java
@@ -34,13 +34,11 @@ public class GithubUsers implements Parcelable{
         }
     };
 
-    public GithubUsers(String userName, String profileImage, String email, String htmlUrl, String company) {
-
-        this.userName = userName;
-        this.profileImage = profileImage;
-        this.email = email;
-        this.htmlUrl = htmlUrl;
-        this.company = company;
+    public GithubUsers(String userNameValue, String profileImageValue, String emailValue, String htmlUrlValue) {
+        this.userName = userNameValue;
+        this.profileImage = profileImageValue;
+        this.email = emailValue;
+        this.htmlUrl = htmlUrlValue;
     }
 
     public GithubUsers(Parcel source) {

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+json_key_file("") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
+package_name("com.example.wagubibrian.github_connect") # e.g. com.krausefx.app

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,58 @@
+default_platform :android
+
+platform :android do
+    before_all do
+        ENV["SLACK_URL"] = "https://hooks.slack.com/services/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"
+    end
+
+    ######################### PUBLIC LANES #########################
+
+    desc "Deploy a new Dev APK to #converge-codelab-qa channel"
+    lane :dev do |options|
+        build(
+            flavor: "Dev"
+        )
+        upload_to_slack()
+    end
+
+
+    ######################### PRIVATE LANES #########################
+
+    desc "Build a new APK"
+    private_lane :build do |options|
+        gradle(
+            task: "clean assemble",
+            build_type: "Release"
+        )
+    end
+
+    desc "Upload the latest output APK to #converge-codelab-QA Slack channel"
+    private_lane :upload_to_slack do |options|
+        full_file_path = lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+        file_name = full_file_path.gsub(/\/.*\//,"")
+        sh "echo Uploading " + file_name + " to #converge-codelab-QA Slack"
+        sh "curl https://slack.com/api/files.upload -F token=\"xoxp-424384161762-444215239027-444219583828-f17f17abf2312ef367c3c3f528d7cdc1\" -F channels=\"converge-codelab-qa\" -F title=\"" + file_name + "\" -F filename=\"" + file_name + "\" -F file=@" + full_file_path
+    end
+
+    ######################### UTILS #########################
+
+    ######################### POST #########################
+
+    after_all do |lane|
+        file_name = lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH].gsub(/\/.*\//,"")
+        slack(
+            message: "Kampala Java Developers Successfully deployed App !:",
+            default_payloads: [
+                :git_branch,
+                :last_git_commit_hash,
+                :last_git_commit_message
+            ],
+            payload: {
+                # Optional, lets you specify any number of your own Slack attachments.
+                "Build Date" => Time.new.to_s,
+                "APK" => file_name
+            },
+            success: true
+        )
+    end
+end


### PR DESCRIPTION
#### What does this PR do?
Adds fastlane integration to the project to enable quick sharing of apk on slack.
#### Description of Task to be completed?
Add fastlane integration by adding fastfile to the project. Setup incoming webhhook on slack and also get legacy token to enable pushing of apkm to slack.
#### How should this be manually tested?
- Clone the repository.
- Run the command `fastlane dev` in the terminal when you have navigated to the root of the project.
#### What are the relevant pivotal tracker stories?
[#156005300](https://www.pivotaltracker.com/story/show/156005300)
#### Screenshots (if appropriate)
<img width="730" alt="screen shot 2018-09-28 at 11 50 13" src="https://user-images.githubusercontent.com/39958516/46198538-6457b800-c315-11e8-867a-fa08adde8e87.png">
